### PR TITLE
Edit the check of `sum(accr_param) == 1` in `create_arm()`

### DIFF
--- a/R/class_arm.R
+++ b/R/class_arm.R
@@ -111,7 +111,7 @@ create_arm <- function(size,
       stop("Number of accrual intervals (accr_interval) does not match number of
          accrual parameters (accr_param).", call.=F)
     }
-    if (length(accr_interval) > 2 & sum(accr_param) != 1) {
+    if (length(accr_interval) > 2 & !is_almost_k(sum(accr_param), k = 1L)) {
       stop("accr_param must sum to 1.", call.=F)
     }
   } else if (is.na(accr_param) | length(accr_param) > 1) {
@@ -319,4 +319,9 @@ create_arm_lachin <- function(size,
 #' @export
 per2haz <- function(x, per=0.5) {
   -log(1-per)/x
+}
+
+#' @noRd
+is_almost_k <- function(x, k, tol = .Machine$double.eps^0.5) {
+  abs(x - k) < tol
 }


### PR DESCRIPTION
An example where `create_arm()` doesn't work:

```
# During an 8-month enrollment period, the first month has an enrollment rate of 2, 
# the second month has a rate of 10.8, and the remaining 6 months have an enrollment rate of 30.2. 
# To achieve a total of 970 patients, these rates (2, 10.8, 30.2) are multiplied by a constant. 
enroll_duration <- c(1, 1, 6)
enroll_rate <- c(2, 10.8, 30.2)

# An error is encountered with the message "Error: accr_param must sum to 1."
npsurvSS::create_arm(size = 970, accr_time = 8, accr_interval = c(1, 2, 8), 
                                       # vector of probabilities a patient is enrolled in each interval
                                       accr_param = enroll_duration * enroll_rate / sum(enroll_duration * enroll_rate),
                                       surv_cure = 0, surv_interval = c(0, 3, Inf), surv_shape = 1, surv_scale = log(2) /  10,
                                       loss_shape = 1, loss_scale = 0.001)
 ```

Upon further investigation, I realized that the check `sum(accr_param) != 1` in `create_arm()` is too strict. This check does not account for the possibility of sum(accr_param) being very close to 1, but not exactly 1, due to the numerical rounding issues inherent in R.